### PR TITLE
Set `junkpaths = TRUE` when unzipping the analysis output

### DIFF
--- a/R/ShinyApps.R
+++ b/R/ShinyApps.R
@@ -41,7 +41,7 @@ prepareForEvidenceExplorer <- function(resultsZipFile, dataFolder, prettyLabels 
   }
   tempFolder <- paste(tempdir(), "unzip")
   on.exit(unlink(tempFolder, recursive = TRUE))
-  utils::unzip(resultsZipFile, exdir = tempFolder)
+  utils::unzip(resultsZipFile, exdir = tempFolder, junkpaths = TRUE)
   databaseFileName <- file.path(tempFolder, "database.csv")
   if (!file.exists(databaseFileName)) {
     stop("Cannot find file database.csv in zip file")


### PR DESCRIPTION
This was necessary for `prepareForEvidenceExplorer` to work on my Mac. You didn't encounter this problem @msuchard?